### PR TITLE
added function to reset url parameters

### DIFF
--- a/assets/javaScript/globals.js
+++ b/assets/javaScript/globals.js
@@ -33,3 +33,8 @@ function getCountryFromUniID(universityID) {
 function render(parentElement, ...element) {
   document.querySelector(parentElement).append(...element);
 }
+
+function resetUrlParameter() {
+  let url = window.location.href.split("?")[0];
+  window.history.replaceState( {} , "Title", `${url}` )
+};


### PR DESCRIPTION
Har laggt till en funktion som man kan kalla på för att resetta url parametrar utan att ladda om sidan.
Kan vara så att det behövs på tex söksidan. Kallas på via `resetUrlParameter();`